### PR TITLE
Allow a Safe Base interpreter to load tksvg

### DIFF
--- a/generic/tkImgSVG.c
+++ b/generic/tkImgSVG.c
@@ -932,3 +932,32 @@ Tksvg_Init(Tcl_Interp *interp)
     Tcl_PkgProvide(interp, PACKAGE_NAME, PACKAGE_VERSION);
     return TCL_OK;
 }
+
+int DLLEXPORT
+Tksvg_SafeInit(Tcl_Interp *interp)
+{
+    if (interp == NULL) {
+        return TCL_ERROR;
+    }
+#ifdef USE_TCL_STUBS
+    if (Tcl_InitStubs(interp, TCL_VERSION, 0) == NULL) {
+	return TCL_ERROR;
+    }
+#else
+    if (Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 0) == NULL) {
+	return TCL_ERROR;
+    }
+#endif
+#ifdef USE_TK_STUBS
+    if (Tk_InitStubs(interp, TCL_VERSION, 0) == NULL) {
+	return TCL_ERROR;
+    }
+#else
+    if (Tcl_PkgRequire(interp, "Tk", TK_VERSION, 0) == NULL) {
+	return TCL_ERROR;
+    }
+#endif
+    Tk_CreatePhotoImageFormat(&tkImgFmtSVGnano);
+    Tcl_PkgProvide(interp, PACKAGE_NAME, PACKAGE_VERSION);
+    return TCL_OK;
+}

--- a/tests/all.tcl
+++ b/tests/all.tcl
@@ -1,0 +1,32 @@
+# all.tcl --
+#
+# This file contains a top-level script to run all of the Tcl
+# tests.  Execute it by invoking "source all.test" when running tcltest
+# in this directory.
+#
+# Copyright (c) 1998-1999 by Scriptics Corporation.
+# Copyright (c) 2000 by Ajuba Solutions
+#
+# See the file "license.terms" for information on usage and redistribution
+# of this file, and for a DISCLAIMER OF ALL WARRANTIES.
+
+package require Tcl 8.5-
+package require tcltest 2.5
+namespace import ::tcltest::*
+
+configure {*}$argv -testdir [file dirname [file dirname [file normalize [
+    info script]/...]]]
+
+if {[singleProcess]} {
+    interp debug {} -frame 1
+}
+
+set ErrorOnFailures [info exists env(ERROR_ON_FAILURES)]
+unset -nocomplain env(ERROR_ON_FAILURES)
+if {[runAllTests] && $ErrorOnFailures} {exit 1}
+# if calling direct only (avoid rewrite exit if inlined or interactive):
+if { [info exists ::argv0] && [file tail $::argv0] eq [file tail [info script]]
+  && !([info exists ::tcl_interactive] && $::tcl_interactive)
+} {
+    proc exit args {}
+}

--- a/tests/small.svg
+++ b/tests/small.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width='14' height='8' version='1.1' xmlns='http://www.w3.org/2000/svg'>
+ <circle cx='7' cy='4' r='3' fill='#141312'/>
+</svg>

--- a/tests/tksvg-safe.test
+++ b/tests/tksvg-safe.test
@@ -1,0 +1,106 @@
+package require tcltest 2
+namespace import -force ::tcltest::*
+
+package require Tk
+package require tksvg
+
+::safe::interpCreate safeInterp
+safe::loadTk safeInterp
+safeInterp eval package require tksvg
+
+set smallImage {<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width='14' height='8' version='1.1' xmlns='http://www.w3.org/2000/svg'>
+ <circle cx='7' cy='4' r='3' fill='#141312'/>
+</svg>}
+
+
+test tksvg-unsafe-1.1 "create from file" -constraints {} -setup {
+} -body {
+    image create photo small -file small.svg
+} -cleanup {
+    image delete small
+} -result small
+
+test tksvg-unsafe-1.2 "create from data" -constraints {} -setup {
+} -body {
+    image create photo small -data $smallImage
+} -cleanup {
+    image delete small
+} -result small
+
+test tksvg-unsafe-1.3 "read from file" -constraints {} -setup {
+    image create photo small
+} -body {
+    small read small.svg
+} -cleanup {
+    image delete small
+} -result {}
+
+test tksvg-unsafe-1.4 "write to file as SVG" -constraints {} -setup {
+    image create photo small -data $smallImage
+} -body {
+    small write .tmp-small-out.svg
+} -cleanup {
+    image delete small
+    file delete .tmp-small-out.svg
+} -returnCodes 1 -result {image file format "svg" has no file writing capability}
+
+test tksvg-unsafe-1.5 "write to file as PNG" -constraints {} -setup {
+    image create photo small -data $smallImage
+} -body {
+    small write .tmp-small-out.png -format PNG
+} -cleanup {
+    image delete small
+    file delete .tmp-small-out.png
+} -result {}
+
+test tksvg-safe-2.1 "create from file, safe interp" -constraints {} -setup {
+} -body {
+    safeInterp eval image create photo small -file small.svg
+} -cleanup {
+    catch {safeInterp eval image delete small}
+} -returnCodes 1 -result {can't get image from a file in a safe interpreter}
+
+test tksvg-safe-2.2 "create from data, safe interp" -constraints {} -setup {
+} -body {
+    safeInterp eval [list image create photo small -data $smallImage]
+} -cleanup {
+    catch {safeInterp eval image delete small}
+} -result small
+
+test tksvg-safe-2.3 "read from file, safe interp" -constraints {} -setup {
+    safeInterp eval image create photo small
+} -body {
+    safeInterp eval small read small.svg
+} -cleanup {
+    catch {safeInterp eval image delete small}
+} -returnCodes 1 -result {can't get image from a file in a safe interpreter}
+
+test tksvg-safe-2.4 "write to file as SVG, safe interp" -constraints {} -setup {
+    safeInterp eval [list image create photo small -data $smallImage]
+} -body {
+    safeInterp eval small write .tmp-small-out.svg
+} -cleanup {
+    catch {safeInterp eval image delete small}
+    catch {file delete .tmp-small-out.svg}
+} -returnCodes 1 -result {can't write image to a file in a safe interpreter}
+
+test tksvg-safe-2.5 "write to file as PNG, safe interp" -constraints {} -setup {
+    safeInterp eval [list image create photo small -data $smallImage]
+} -body {
+    safeInterp eval small write .tmp-small-out.png -format PNG
+} -cleanup {
+    catch {safeInterp eval image delete small}
+    catch {file delete .tmp-small-out.png}
+} -returnCodes 1 -result {can't write image to a file in a safe interpreter}
+
+
+# cleanup
+safe::interpDelete safeInterp
+::tcltest::cleanupTests
+return
+
+# Local Variables:
+# mode: tcl
+# End:
+


### PR DESCRIPTION
* Add a safe entry point to generic/tkImgSVG.c
* Add tests for the use of tksvg in a Safe Base interpreter
* *  (tests are not integrated with the Makefile "make test", but can be run from a tclsh/wish shell)